### PR TITLE
Upload and process MD images with no channel information within filename

### DIFF
--- a/tmlib/workflow/metaconfig/base.py
+++ b/tmlib/workflow/metaconfig/base.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 _SUPPORTED__FIELDS = {'w', 'c', 'z', 't', 's'}
 
 
-_FIELD_DEFAULTS = {'w': 'A01', 'z': 0, 't': 0, 's': 0}
+_FIELD_DEFAULTS = {'w': 'A01', 'c': 1, 'z': 0, 't': 0, 's': 0}
 
 
 MetadataFields = collections.namedtuple(

--- a/tmlib/workflow/metaconfig/metamorph.py
+++ b/tmlib/workflow/metaconfig/metamorph.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 #: Regular expression pattern to identify image files
 # TODO: how are time points encoded?
-IMAGE_FILE_REGEX_PATTERN = '.+_?(?P<w>[A-Z]\d{2})_s(?P<s>\d+)_w(?P<c>\d{1})[^_thumb]'
+
+IMAGE_FILE_REGEX_PATTERN = '.+_?(?P<w>[A-Z]\d{2})_s(?P<s>\d+)(_w(?P<c>\d{1}))?[^_thumb]'
 
 #: Supported extensions for metadata files
 METADATA_FILE_REGEX_PATTERN = r'(?!.*)'
@@ -54,9 +55,8 @@ class MetamorphMetadataHandler(MetadataHandler):
         omexml_images: Dict[str, bioformats.omexml.OMEXML]
             metadata extracted from microscope image files
         omexml_metadata: bioformats.omexml.OMEXML
-            metadata extracted from microscope metadata files 
+            metadata extracted from microscope metadata files
         '''
         super(MetamorphMetadataHandler, self).__init__(
             omexml_images, omexml_metadata
         )
-


### PR DESCRIPTION
The MD images without channel information within the filename could not be uploaded into TM. I included the new REGEX pattern suggested by @hackermd  to parse those filenames. Yet, I added  the missing default channel value in the _FIELD_DEFAULTS dictionary images so that images without channel information can be also processed. I tested the upload and image processing step for such files on a private instance and it works fine.  