### PR TITLE
Update jterator code for restructured jtlib repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setuptools.setup(
        'geoalchemy2>=0.3.0',
        'h5py>=2.5.0',
        'image-registration==0.2.1',
-       'jtmodules>=0.1.0',
+       'jtlib>=0.3.2',
        'mahotas>=1.4.1',
        'matplotlib>=2.0.0',
        'mock>=1.0.1',

--- a/tmlib/config.py
+++ b/tmlib/config.py
@@ -232,7 +232,7 @@ class LibraryConfig(TmapsConfig):
 
     def __init__(self):
         super(LibraryConfig, self).__init__()
-        self.modules_home = '~/jtmodules'
+        self.modules_home = '~/jtlibrary/modules'
         self.formats_home = '~/tmformats'
         self.storage_home = '/storage/filesystem'
         self._resource = None
@@ -261,15 +261,8 @@ class LibraryConfig(TmapsConfig):
 
     @property
     def modules_home(self):
-        '''str: absolute path to root directory of local copy of
-        *TissueMAPS/JtModules* repository (default: ``"~/jtmodules"``)
-
-        Note
-        ----
-        Assumes a certain repository structure, where *jtmodules* packages
-        for different programming languages are placed into a
-        language-specific ``src`` subdirectory, such as ``src/python/jtmodules``
-        or ``src/matlab/+jtmodules``.
+        '''str: absolute path to the directory that contains the jterator
+        module source code files (default: ``"~/jtlibrary/modules"``)
         '''
         return os.path.expandvars(os.path.expanduser(
             self._config.get(self._section, 'modules_home')

--- a/tmlib/workflow/jterator/api.py
+++ b/tmlib/workflow/jterator/api.py
@@ -105,16 +105,20 @@ class ImageAnalysisPipelineEngine(WorkflowStepAPI):
         for i, element in enumerate(self.project.pipe.description.pipeline):
             if not element.active:
                 continue
-            source_file = element.source
+            source_file = str(element.source)  # copy
             if '/' in source_file:
+                logger.debug('assume module resides outside %s', cfg.module_home)
                 source_file = os.path.expandvars(source_file)
                 source_file = os.path.expanduser(source_file)
                 if not os.path.isabs(source_file):
                     source_file = os.path.join(self.step_location, source_file)
-                if not os.path.exists(source_file):
-                    raise PipelineDescriptionError(
-                        'Module file does not exist: %s' % source_file
-                    )
+            else:
+                logger.debug('assume module resides in %s', cfg.module_home)
+                source_file = os.path.join(cfg.module_home, source_file)
+            if not os.path.exists(source_file):
+                raise PipelineDescriptionError(
+                    'Module source code file not found: %s' % element.source
+                )
             name = self.project.handles[i].name
             handles = self.project.handles[i].description
             module = ImageAnalysisModule(

--- a/tmlib/workflow/jterator/module.py
+++ b/tmlib/workflow/jterator/module.py
@@ -116,24 +116,17 @@ class ImageAnalysisModule(object):
 
     def _exec_m_module(self, engine):
         module_name = os.path.splitext(os.path.basename(self.source_file))[0]
-        if os.path.exists(self.source_file):
-            logger.debug(
-                'import module "%s" from source file: %s', self.source_file
-            )
-            logger.debug(
-                'add module source file to Matlab path: "%s"', self.source_file
-            )
-            engine.eval(
-                'addpath(\'{0}\');'.format(os.path.dirname(self.source_file))
-            )
-            engine.eval('version = {0}.version'.format(module_name))
-            function_call_format_string = '[{outputs}] = {name}.main({inputs});'
-        else:
-            logger.debug('import module "%s" from "jtmodules" package')
-            engine.eval('import \'jtmodules.{0}\''.format(module_name))
-            engine.eval('version = jtmodules.{0}.VERSION'.format(module_name))
-            function_call_format_string = \
-                '[{outputs}] = jtmodules.{name}.main({inputs});'
+        logger.debug(
+            'import module "%s" from source file: %s', self.source_file
+        )
+        logger.debug(
+            'add module source file to Matlab path: "%s"', self.source_file
+        )
+        engine.eval(
+            'addpath(\'{0}\');'.format(os.path.dirname(self.source_file))
+        )
+        engine.eval('version = {0}.VERSION'.format(module_name))
+        function_call_format_string = '[{outputs}] = {name}.main({inputs});'
         # NOTE: Matlab doesn't add imported classes to the workspace. It access
         # the "VERSION" property, we need to assign it to a variable first.
         version = engine.get('version')
@@ -173,26 +166,11 @@ class ImageAnalysisModule(object):
 
     def _exec_py_module(self):
         module_name = os.path.splitext(os.path.basename(self.source_file))[0]
-        if os.path.exists(self.source_file):
-            logger.debug(
-                'import module "%s" from source file: %s',
-                module_name, self.source_file
-            )
-            module = imp.load_source(module_name, self.source_file)
-        else:
-            logger.debug('import module "%s" from "jtmodules" package')
-            try:
-                import jtmodules
-            except ImportError:
-                raise ImportError('Package "jtmodules" is not installed.')
-            try:
-                module = importlib.import_module('jtmodules.%s' % module_name)
-            except ImportError as err:
-                raise ImportError(
-                    'Module "%s" could not be imported:\n%s' % (
-                        module_name, str(err)
-                    )
-                )
+        logger.debug(
+            'import module "%s" from source file: %s',
+            module_name, self.source_file
+        )
+        module = imp.load_source(module_name, self.source_file)
         if module.VERSION != self.handles.version:
             raise PipelineRunError(
                 'Version of source and handles is not the same.'
@@ -238,17 +216,12 @@ class ImageAnalysisModule(object):
                 '"rpy2" package is not installed.'
             )
         module_name = os.path.splitext(os.path.basename(self.source_file))[0]
-        if os.path.exists(self.source_file):
-            logger.debug(
-                'import module "%s" from source file: %s', self.source_file
-            )
-            logger.debug('source module: "%s"', self.source_file)
-            rpy2.robjects.r('source("{0}")'.format(self.source_file))
-            module = rpy2.robjects.r[module_name]
-        else:
-            logger.debug('import module "%s" from "jtmodules" package')
-            rpackage = importr('jtmodules')
-            module = getattr(rpackage, module_name)
+        logger.debug(
+            'import module "%s" from source file: %s', self.source_file
+        )
+        logger.debug('source module: "%s"', self.source_file)
+        rpy2.robjects.r('source("{0}")'.format(self.source_file))
+        module = rpy2.robjects.r[module_name]
         version = module.get('VERSION')[0]
         if version != self.handles.version:
             raise PipelineRunError(

--- a/tmlib/workflow/jterator/utils.py
+++ b/tmlib/workflow/jterator/utils.py
@@ -22,46 +22,8 @@ from tmlib import cfg
 logger = logging.getLogger(__name__)
 
 
-def get_package_directories():
-    '''Gets the language-specific package directories were module source
-    files are located.
-
-    Returns
-    -------
-    Dict[str, str]
-        paths to module directories for each language relative to the
-        repository directory
-    '''
-    dirs = {
-        'Python': 'src/python/jtmodules',
-        'Matlab': 'src/matlab/+jtmodules',
-        'R': 'src/r/jtmodules'
-    }
-    return {k: os.path.join(cfg.modules_home, v) for k, v in dirs.iteritems()}
-
-
-def get_module_path(module_file):
-    '''Gets the absolute path to a module file.
-
-    Parameters
-    ----------
-    module_file: str
-        name of the module file
-    repo_dir: str
-        absolute path to the local copy of the `jtlib` repository
-
-    Returns
-    -------
-    str
-        absolute path to module file
-    '''
-    language = determine_language(module_file)
-    modules_dir = get_package_directories()[language]
-    return os.path.join(modules_dir, module_file)
-
-
 def determine_language(filename):
-    '''Determines language form module filename suffix.
+    '''Determines language of a module from filename suffix.
 
     Parameters
     ----------


### PR DESCRIPTION
Import module source code file from ``jtlibary`` repository instead of ``jtmodules`` repository. Depends on https://github.com/TissueMAPS/JtLibrary/pull/14.