### PR TITLE
Feature yokogawa action

### DIFF
--- a/tmlib/workflow/metaconfig/__init__.py
+++ b/tmlib/workflow/metaconfig/__init__.py
@@ -180,12 +180,10 @@ def metadata_handler_factory(microscope_type):
     '''
     module = import_microscope_type_module(microscope_type)
     handler_cls = None
-    for k, v in vars(module).iteritems():
-        if inspect.isclass(v):
-            if (MetadataHandler in inspect.getmro(v) and
-                    not inspect.isabstract(v)):
-                handler_cls = v
-                break
+    for k, v in inspect.getmembers(module):
+        if inspect.isclass(v) and MetadataHandler in v.__bases__:
+            handler_cls = v
+            break 
     if handler_cls is None:
         raise AttributeError(
             'Module "%s" does not implement a MetadataHandler class.' %

--- a/tmlib/workflow/metaconfig/cellvoyager.py
+++ b/tmlib/workflow/metaconfig/cellvoyager.py
@@ -34,7 +34,7 @@ from tmlib.workflow.metaconfig.omexml import XML_DECLARATION
 logger = logging.getLogger(__name__)
 
 #: Regular expression pattern to identify image files
-IMAGE_FILE_REGEX_PATTERN = r'[^_]+_(?P<w>[A-Z]\d{2})_T(?P<t>\d+)F(?P<s>\d+)L\d+A\d+Z(?P<z>\d+)C0(?P<c>\d)\.'
+IMAGE_FILE_REGEX_PATTERN = r'[^_]+_(?P<w>[A-Z]\d{2})_T(?P<t>\d+)F(?P<s>\d+)L\d+A\d+Z(?P<z>\d+)(?P<c>[C]\d{2})\.'
 
 #: Supported extensions for metadata files
 METADATA_FILE_REGEX_PATTERN = r'.*\.(mlf|mrf)$'
@@ -65,6 +65,17 @@ class CellvoyagerMetadataHandler(MetadataHandler):
         return stitch.calc_grid_coordinates_from_positions(
             positions, n, reverse_rows=True
         )
+
+    @classmethod
+    def extract_fields_from_filename(cls, regex, filename, defaults=True):
+        MetadataFields = super (CellvoyagerMetadataHandler, cls).extract_fields_from_filename(regex, filename, defaults=True)
+        
+        # Specific for this class
+        action = re.search('L01(.+?)Z', filename) # Look for action and change the channel accordingly
+        action_number = action.group(1)
+        MetadataFields = MetadataFields._replace(c=action_number+"_"+MetadataFields.c)
+
+        return MetadataFields
 
 
 class CellvoyagerMetadataReader(MetadataReader):


### PR DESCRIPTION
cellvoyager.py --> The new REGEX allows for a more explicit description; e.g. `C01` in place of `1`, in view of having the action number also part of the channel. The `extract_fields_from_filename` function overrides the same function defined in the base class extending its functionality to parse `actions`, specific for YOKOGAWA microscope

__init__.py --> The `metadata_handler_factory` function was not returning the microscope specific MetadataHandler subclass, so I change it accordingly   