### PR TITLE
Jterator inputs with channel-specific dimensions (rebased)

### DIFF
--- a/tmlib/workflow/jterator/api.py
+++ b/tmlib/workflow/jterator/api.py
@@ -258,18 +258,6 @@ class ImageAnalysisPipelineEngine(WorkflowStepAPI):
         objects_input = self.project.pipe.description.input.objects
         with tm.utils.ExperimentSession(self.experiment_id) as session:
             site = session.query(tm.Site).get(site_id)
-
-            records = session.query(tm.ChannelImageFile.tpoint).\
-                filter_by(site_id=site.id).\
-                distinct()
-            tpoints = [r.tpoint for r in records]
-            n_tpoints = len(tpoints)
-            records = session.query(tm.ChannelImageFile.zplane).\
-                filter_by(site_id=site.id).\
-                distinct()
-            zplanes = [r.zplane for r in records]
-            n_zplanes = len(zplanes)
-
             y_offset, x_offset = site.aligned_offset
             height = site.aligned_height
             width = site.aligned_width
@@ -284,6 +272,18 @@ class ImageAnalysisPipelineEngine(WorkflowStepAPI):
                     dtype = np.uint16
                 elif channel.bit_depth == 8:
                     dtype = np.uint8
+
+                records = session.query(tm.ChannelImageFile.tpoint).\
+                    filter_by(site_id=site.id,channel_id=channel.id).\
+                    distinct()
+                tpoints = [r.tpoint for r in records]
+                n_tpoints = len(tpoints)
+                records = session.query(tm.ChannelImageFile.zplane).\
+                    filter_by(site_id=site.id,channel_id=channel.id).\
+                    distinct()
+                zplanes = [r.zplane for r in records]
+                n_zplanes = len(zplanes)
+
                 image_array = np.zeros(
                     (height, width, n_zplanes, n_tpoints), dtype
                 )


### PR DESCRIPTION
https://github.com/TissueMAPS/TmLibrary/pull/35 rebased against current master branch. See https://github.com/TissueMAPS/TmLibrary/pull/35 for further discussion.